### PR TITLE
Add Repository::cherrypick_commit()

### DIFF
--- a/libgit2-sys/lib.rs
+++ b/libgit2-sys/lib.rs
@@ -3470,6 +3470,14 @@ extern "C" {
         commit: *mut git_commit,
         options: *const git_cherrypick_options,
     ) -> c_int;
+    pub fn git_cherrypick_commit(
+        out: *mut *mut git_index,
+        repo: *mut git_repository,
+        cherrypick_commit: *mut git_commit,
+        our_commit: *mut git_commit,
+        mainline: c_uint,
+        merge_options: *const git_merge_options,
+    ) -> c_int;
 }
 
 pub fn init() {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -2469,6 +2469,29 @@ impl Repository {
         }
     }
 
+    /// Create an index of uncommitted changes, representing the result of
+    /// cherry-picking.
+    pub fn cherrypick_commit(
+        &self,
+        cherrypick_commit: &Commit<'_>,
+        our_commit: &Commit<'_>,
+        mainline: u32,
+        options: Option<&MergeOptions>,
+    ) -> Result<Index, Error> {
+        let mut ret = ptr::null_mut();
+        unsafe {
+            try_call!(raw::git_cherrypick_commit(
+                &mut ret,
+                self.raw(),
+                cherrypick_commit.raw(),
+                our_commit.raw(),
+                mainline,
+                options.map(|o| o.raw())
+            ));
+            Ok(Binding::from_raw(ret))
+        }
+    }
+
     /// Retrieves the name of the reference supporting the remote tracking branch,
     /// given the name of a local branch reference.
     pub fn branch_upstream_name(&self, refname: &str) -> Result<Buf, Error> {


### PR DESCRIPTION
This adds `Repository::cherrypick_commit()` as a wrapper around [`git_cherrypick_commit()`](https://libgit2.org/libgit2/#HEAD/group/cherrypick/git_cherrypick_commit).